### PR TITLE
新增帳戶模組與 Web 介面

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+**/__pycache__/

--- a/account.py
+++ b/account.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Alpaca 帳戶相關操作模組。"""
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import List, Optional
+
+from alpaca.trading.client import TradingClient
+from alpaca.trading.requests import GetOrdersRequest
+from alpaca.trading.enums import OrderStatus
+
+
+def connect(api_key: str, secret_key: str, *, paper: bool = True) -> TradingClient:
+    """建立並回傳 :class:`TradingClient`."""
+    return TradingClient(api_key, secret_key, paper=paper)
+
+
+def get_account_info(client: TradingClient) -> dict:
+    """取得帳戶資訊，並轉為易讀格式。"""
+    acct = client.get_account()
+    buying_power = Decimal(str(acct.buying_power)).quantize(
+        Decimal("0.01"), ROUND_HALF_UP
+    )
+    return {
+        "status": acct.status,
+        "equity": str(acct.equity),
+        "buying_power": str(buying_power),
+    }
+
+
+def get_positions(client: TradingClient):
+    """取得帳戶持倉資料列表。"""
+    return client.get_all_positions()
+
+
+def get_trade_history(
+    client: TradingClient,
+    *,
+    status: OrderStatus = OrderStatus.CLOSED,
+    limit: Optional[int] = None,
+) -> list:
+    """取得歷史訂單（交易）紀錄。"""
+    req = GetOrdersRequest(status=status, limit=limit)
+    return client.get_orders(req)

--- a/api.py
+++ b/api.py
@@ -1,0 +1,40 @@
+"""提供簡易 Web API 的介面。"""
+
+from fastapi import FastAPI, HTTPException
+from typing import Optional
+
+import account
+import config
+
+app = FastAPI(title="Alpaca Trading API")
+
+_client = None
+
+
+def _ensure_client():
+    global _client
+    if _client is None:
+        if not config.ALPACA_API_KEY or not config.ALPACA_SECRET_KEY:
+            raise HTTPException(status_code=400, detail="API key 尚未設定")
+        _client = account.connect(
+            config.ALPACA_API_KEY, config.ALPACA_SECRET_KEY, paper=config.USE_PAPER
+        )
+    return _client
+
+
+@app.get("/account")
+def get_account():
+    client = _ensure_client()
+    return account.get_account_info(client)
+
+
+@app.get("/positions")
+def positions():
+    client = _ensure_client()
+    return account.get_positions(client)
+
+
+@app.get("/orders")
+def orders(limit: Optional[int] = None):
+    client = _ensure_client()
+    return account.get_trade_history(client, limit=limit)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,5 @@
+"""交易機器人設定檔。"""
+
+ALPACA_API_KEY = ""
+ALPACA_SECRET_KEY = ""
+USE_PAPER = True

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="utf-8">
+    <title>Alpaca Dashboard</title>
+</head>
+<body>
+    <h1>Alpaca Trading Dashboard</h1>
+    <p>此處可顯示帳戶資訊與交易狀態。</p>
+</body>
+</html>

--- a/invesment.py
+++ b/invesment.py
@@ -17,6 +17,8 @@ from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import MarketOrderRequest
 from alpaca.trading.enums import OrderSide, TimeInForce
 
+import account
+
 # ────────────────────────────────────────────────
 # 0. 清理殘留的 default root（Spyder 反覆執行時必要）
 # ────────────────────────────────────────────────
@@ -53,7 +55,7 @@ def connect_account() -> None:
     """建立 TradingClient 並取得帳戶資訊。"""
     global client
 
-    api_key    = api_key_var.get()
+    api_key = api_key_var.get()
     secret_key = secret_key_var.get()
     paper_mode = use_paper_var.get()
 
@@ -62,17 +64,14 @@ def connect_account() -> None:
         return
 
     try:
-        client = TradingClient(api_key, secret_key, paper=paper_mode)
-        acct   = client.get_account()
+        client = account.connect(api_key, secret_key, paper=paper_mode)
+        info = account.get_account_info(client)
 
-        buying_power = Decimal(str(acct.buying_power)).quantize(
-            Decimal("0.01"), ROUND_HALF_UP
-        )
         msg = (
-            f"帳戶連線成功！\n"
-            f"狀態：{acct.status}\n"
-            f"總淨值（Equity）：${acct.equity}\n"
-            f"可用買進金額（Buying Power）：${buying_power}"
+            "帳戶連線成功！\n"
+            f"狀態：{info['status']}\n"
+            f"總淨值（Equity）：${info['equity']}\n"
+            f"可用買進金額（Buying Power）：${info['buying_power']}"
         )
         _show_result(msg)
         messagebox.showinfo("成功", "帳戶連線並取得資訊成功！")

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,5 @@
+"""策略模組集合。"""
+
+from .base import BaseStrategy
+
+__all__ = ["BaseStrategy"]

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,0 +1,18 @@
+"""交易策略接口基類。"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseStrategy(ABC):
+    """所有策略應繼承此類並實作對應方法。"""
+
+    @abstractmethod
+    def on_data(self, data: Any) -> None:
+        """接收即時資料後呼叫。"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def generate_signals(self) -> None:
+        """產生交易訊號。"""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- 新增 `account.py` 提供連線、查詢持倉與歷史交易紀錄功能
- 新增 `strategies/` 目錄與基礎策略接口
- 新增 `config.py` 作為交易機器人設定檔
- 建立 FastAPI 的 `api.py` 與簡易 dashboard 頁面
- 修改 GUI (`invesment.py`) 使用新的 `account` 模組

## Testing
- `python -m py_compile invesment.py account.py api.py strategies/__init__.py strategies/base.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_685bd6aec6988329b469bde3a3ebdc49