### PR TITLE
Add dashboard with auto-refresh

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,12 +1,21 @@
 """提供簡易 Web API 的介面。"""
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from pathlib import Path
 from typing import Optional
 
 import account
 import config
 
 app = FastAPI(title="Alpaca Trading API")
+
+
+@app.get("/")
+def dashboard():
+    """回傳前端儀表板頁面"""
+    path = Path(__file__).parent / "dashboard" / "index.html"
+    return FileResponse(path)
 
 _client = None
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3,9 +3,48 @@
 <head>
     <meta charset="utf-8">
     <title>Alpaca Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .section { margin-bottom: 20px; }
+        pre { background: #f4f4f4; padding: 10px; }
+    </style>
 </head>
 <body>
     <h1>Alpaca Trading Dashboard</h1>
-    <p>此處可顯示帳戶資訊與交易狀態。</p>
+
+    <div class="section">
+        <h2>Account</h2>
+        <pre id="account">載入中...</pre>
+    </div>
+
+    <div class="section">
+        <h2>Positions</h2>
+        <pre id="positions">載入中...</pre>
+    </div>
+
+    <div class="section">
+        <h2>Orders</h2>
+        <pre id="orders">載入中...</pre>
+    </div>
+
+    <script>
+    async function fetchData() {
+        try {
+            const [account, positions, orders] = await Promise.all([
+                fetch('/account').then(r => r.json()),
+                fetch('/positions').then(r => r.json()),
+                fetch('/orders?limit=5').then(r => r.json())
+            ]);
+            document.getElementById('account').textContent = JSON.stringify(account, null, 2);
+            document.getElementById('positions').textContent = JSON.stringify(positions, null, 2);
+            document.getElementById('orders').textContent = JSON.stringify(orders, null, 2);
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
+    fetchData();
+    setInterval(fetchData, 10000);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance dashboard front-end
- periodically fetch account, position and order data
- serve dashboard via root route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0bbe1b9883298340d17284d22955