### PR TITLE
Add robots management and API route

### DIFF
--- a/api.py
+++ b/api.py
@@ -5,6 +5,8 @@ from fastapi.responses import FileResponse
 from pathlib import Path
 from typing import Optional
 
+import robots
+
 import account
 import config
 
@@ -47,3 +49,9 @@ def positions():
 def orders(limit: Optional[int] = None):
     client = _ensure_client()
     return account.get_trade_history(client, limit=limit)
+
+
+@app.get("/bots")
+def bots() -> list:
+    """取得所有交易機器人資訊。"""
+    return robots.get_bots()

--- a/robots.py
+++ b/robots.py
@@ -1,0 +1,46 @@
+"""簡易交易機器人資訊管理模組。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+# 機器人資訊儲存檔案
+_ROBOTS_FILE = Path(__file__).with_name("robots.json")
+
+# 內部快取
+_bots: List[Dict[str, Any]] | None = None
+
+
+def _load() -> List[Dict[str, Any]]:
+    global _bots
+    if _bots is None:
+        if _ROBOTS_FILE.exists():
+            text = _ROBOTS_FILE.read_text(encoding="utf-8")
+            try:
+                _bots = json.loads(text)
+            except json.JSONDecodeError:
+                _bots = []
+        else:
+            _bots = []
+    return _bots
+
+
+def _save() -> None:
+    if _bots is not None:
+        _ROBOTS_FILE.write_text(
+            json.dumps(_bots, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+
+def get_bots() -> List[Dict[str, Any]]:
+    """取得所有交易機器人資訊。"""
+    return list(_load())
+
+
+def add_bot(bot: Dict[str, Any]) -> None:
+    """新增一個交易機器人並存檔。"""
+    bots = _load()
+    bots.append(bot)
+    _save()

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+import pytest
+
+root_path = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_path))
+
+import robots
+
+
+def test_get_bots_from_file(tmp_path, monkeypatch):
+    data_file = tmp_path / "robots.json"
+    data_file.write_text('[{"name": "bot1"}]', encoding="utf-8")
+
+    monkeypatch.setattr(robots, "_ROBOTS_FILE", data_file)
+    robots._bots = None
+
+    bots = robots.get_bots()
+    assert bots == [{"name": "bot1"}]
+
+
+def test_api_get_bots(tmp_path):
+    pytest.importorskip("fastapi")
+    pytest.importorskip("alpaca")
+    from fastapi.testclient import TestClient
+    import importlib
+    api = importlib.import_module("api")
+
+    data_file = tmp_path / "robots.json"
+    data_file.write_text('[{"name": "api_bot"}]', encoding="utf-8")
+
+    import robots as robots_mod
+    robots_mod._ROBOTS_FILE = data_file
+    robots_mod._bots = None
+
+    client = TestClient(api.app)
+    resp = client.get("/bots")
+    assert resp.status_code == 200
+    assert resp.json() == [{"name": "api_bot"}]


### PR DESCRIPTION
## Summary
- 新增 `robots.py` 負責儲存及管理交易機器人
- 在 `api.py` 加入 `/bots` 路由
- 新增 `tests/test_bots.py` 測試機器人模組與 `/bots` API (若環境缺少 fastapi 則略過)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0ce7ebf883299e1e3947fd075332