### PR TITLE
Implement robot management

### DIFF
--- a/api.py
+++ b/api.py
@@ -55,3 +55,36 @@ def orders(limit: Optional[int] = None):
 def bots() -> list:
     """取得所有交易機器人資訊。"""
     return robots.get_bots()
+
+
+@app.post("/bots")
+def create_bot(bot: dict):
+    """新增一個交易機器人。"""
+    robots.add_bot(bot)
+    return {"id": len(robots.get_bots()) - 1}
+
+
+@app.get("/bots/{bot_id}")
+def get_bot(bot_id: int):
+    bots = robots.get_bots()
+    if bot_id < 0 or bot_id >= len(bots):
+        raise HTTPException(status_code=404, detail="Bot not found")
+    return bots[bot_id]
+
+
+@app.put("/bots/{bot_id}")
+def update_bot(bot_id: int, bot: dict):
+    try:
+        robots.update_bot(bot_id, bot)
+    except IndexError:
+        raise HTTPException(status_code=404, detail="Bot not found")
+    return {"success": True}
+
+
+@app.delete("/bots/{bot_id}")
+def delete_bot(bot_id: int):
+    try:
+        robots.delete_bot(bot_id)
+    except IndexError:
+        raise HTTPException(status_code=404, detail="Bot not found")
+    return {"success": True}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -27,6 +27,13 @@
         <pre id="orders">載入中...</pre>
     </div>
 
+    <div class="section">
+        <h2>Bots</h2>
+        <ul id="bots"></ul>
+        <input id="new-bot-name" placeholder="Bot name">
+        <button onclick="addBot()">Add</button>
+    </div>
+
     <script>
     async function fetchData() {
         try {
@@ -43,7 +50,54 @@
         }
     }
 
+    async function loadBots() {
+        try {
+            const bots = await fetch('/bots').then(r => r.json());
+            const list = document.getElementById('bots');
+            list.innerHTML = '';
+            bots.forEach((bot, idx) => {
+                const li = document.createElement('li');
+                const input = document.createElement('input');
+                input.value = bot.name || '';
+                input.onchange = () => updateBot(idx, {name: input.value});
+                li.appendChild(input);
+                const delBtn = document.createElement('button');
+                delBtn.textContent = 'Delete';
+                delBtn.onclick = () => deleteBot(idx);
+                li.appendChild(delBtn);
+                list.appendChild(li);
+            });
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
+    async function addBot() {
+        const name = document.getElementById('new-bot-name').value;
+        await fetch('/bots', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({name})
+        });
+        document.getElementById('new-bot-name').value = '';
+        loadBots();
+    }
+
+    async function updateBot(id, bot) {
+        await fetch(`/bots/${id}`, {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(bot)
+        });
+    }
+
+    async function deleteBot(id) {
+        await fetch(`/bots/${id}`, {method: 'DELETE'});
+        loadBots();
+    }
+
     fetchData();
+    loadBots();
     setInterval(fetchData, 10000);
     </script>
 </body>

--- a/robots.py
+++ b/robots.py
@@ -44,3 +44,21 @@ def add_bot(bot: Dict[str, Any]) -> None:
     bots = _load()
     bots.append(bot)
     _save()
+
+
+def update_bot(bot_id: int, bot: Dict[str, Any]) -> None:
+    """更新指定索引的交易機器人資料。"""
+    bots = _load()
+    if bot_id < 0 or bot_id >= len(bots):
+        raise IndexError("bot not found")
+    bots[bot_id] = bot
+    _save()
+
+
+def delete_bot(bot_id: int) -> None:
+    """刪除指定索引的交易機器人。"""
+    bots = _load()
+    if bot_id < 0 or bot_id >= len(bots):
+        raise IndexError("bot not found")
+    del bots[bot_id]
+    _save()

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -37,3 +37,46 @@ def test_api_get_bots(tmp_path):
     resp = client.get("/bots")
     assert resp.status_code == 200
     assert resp.json() == [{"name": "api_bot"}]
+
+
+def test_bot_crud(tmp_path, monkeypatch):
+    data_file = tmp_path / "robots.json"
+    monkeypatch.setattr(robots, "_ROBOTS_FILE", data_file)
+    robots._bots = None
+
+    robots.add_bot({"name": "one"})
+    robots.add_bot({"name": "two"})
+    assert robots.get_bots() == [{"name": "one"}, {"name": "two"}]
+
+    robots.update_bot(1, {"name": "updated"})
+    assert robots.get_bots()[1] == {"name": "updated"}
+
+    robots.delete_bot(0)
+    assert robots.get_bots() == [{"name": "updated"}]
+
+
+def test_api_bot_crud(tmp_path):
+    pytest.importorskip("fastapi")
+    pytest.importorskip("alpaca")
+    from fastapi.testclient import TestClient
+    import importlib
+    api = importlib.import_module("api")
+
+    data_file = tmp_path / "robots.json"
+    import robots as robots_mod
+    robots_mod._ROBOTS_FILE = data_file
+    robots_mod._bots = None
+
+    client = TestClient(api.app)
+
+    resp = client.post("/bots", json={"name": "bot"})
+    assert resp.status_code == 200
+    assert robots_mod.get_bots() == [{"name": "bot"}]
+
+    resp = client.put("/bots/0", json={"name": "bot2"})
+    assert resp.status_code == 200
+    assert robots_mod.get_bots()[0] == {"name": "bot2"}
+
+    resp = client.delete("/bots/0")
+    assert resp.status_code == 200
+    assert robots_mod.get_bots() == []


### PR DESCRIPTION
## Summary
- create update/delete helpers in `robots.py`
- expand FastAPI app with CRUD routes
- add simple frontend section for managing robots
- test add/update/delete logic and API endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c119a92dc8329bb79a2c6a878ae8f