### PR TITLE
Update dashboard UI with tables and external CSS

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3,28 +3,24 @@
 <head>
     <meta charset="utf-8">
     <title>Alpaca Dashboard</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        .section { margin-bottom: 20px; }
-        pre { background: #f4f4f4; padding: 10px; }
-    </style>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <h1>Alpaca Trading Dashboard</h1>
 
     <div class="section">
         <h2>Account</h2>
-        <pre id="account">載入中...</pre>
+        <table id="account"></table>
     </div>
 
     <div class="section">
         <h2>Positions</h2>
-        <pre id="positions">載入中...</pre>
+        <table id="positions"></table>
     </div>
 
     <div class="section">
         <h2>Orders</h2>
-        <pre id="orders">載入中...</pre>
+        <table id="orders"></table>
     </div>
 
     <div class="section">
@@ -35,6 +31,51 @@
     </div>
 
     <script>
+    function renderObjectTable(obj, id) {
+        const table = document.getElementById(id);
+        table.innerHTML = '';
+        for (const [key, value] of Object.entries(obj)) {
+            const tr = document.createElement('tr');
+            const th = document.createElement('th');
+            th.textContent = key;
+            const td = document.createElement('td');
+            td.textContent = value;
+            tr.appendChild(th);
+            tr.appendChild(td);
+            table.appendChild(tr);
+        }
+    }
+
+    function renderArrayTable(arr, id) {
+        const table = document.getElementById(id);
+        table.innerHTML = '';
+        if (!Array.isArray(arr) || arr.length === 0) {
+            return;
+        }
+        const keys = Object.keys(arr[0]);
+        const thead = document.createElement('thead');
+        const headRow = document.createElement('tr');
+        keys.forEach(k => {
+            const th = document.createElement('th');
+            th.textContent = k;
+            headRow.appendChild(th);
+        });
+        thead.appendChild(headRow);
+        table.appendChild(thead);
+        const tbody = document.createElement('tbody');
+        arr.forEach(item => {
+            const tr = document.createElement('tr');
+            keys.forEach(k => {
+                const td = document.createElement('td');
+                const val = item[k];
+                td.textContent = (typeof val === 'object') ? JSON.stringify(val) : val;
+                tr.appendChild(td);
+            });
+            tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+    }
+
     async function fetchData() {
         try {
             const [account, positions, orders] = await Promise.all([
@@ -42,9 +83,9 @@
                 fetch('/positions').then(r => r.json()),
                 fetch('/orders?limit=5').then(r => r.json())
             ]);
-            document.getElementById('account').textContent = JSON.stringify(account, null, 2);
-            document.getElementById('positions').textContent = JSON.stringify(positions, null, 2);
-            document.getElementById('orders').textContent = JSON.stringify(orders, null, 2);
+            renderObjectTable(account, 'account');
+            renderArrayTable(positions, 'positions');
+            renderArrayTable(orders, 'orders');
         } catch (err) {
             console.error(err);
         }

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -1,0 +1,31 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+.section {
+  margin-bottom: 20px;
+}
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-top: 10px;
+}
+th, td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+}
+th {
+  background-color: #f2f2f2;
+}
+input, button {
+  padding: 6px 10px;
+  margin-top: 8px;
+}
+button {
+  cursor: pointer;
+}
+#bots li {
+  margin-bottom: 6px;
+  list-style: none;
+}


### PR DESCRIPTION
## Summary
- add new CSS style sheet for dashboard table layout
- restructure dashboard HTML to use tables instead of `<pre>` tags
- add helper functions to render fetched JSON into tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c2a40246483299d111ea2b7f1357f