### PR TITLE
Add paper trading env flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ pip install -r requirements.txt
 ```dotenv
 APCA_API_KEY_ID=你的APIKey
 APCA_API_SECRET_KEY=你的SecretKey
+# 是否使用 Paper Trading，預設為 true
+ALPACA_USE_PAPER=true
 ```
+
+`ALPACA_USE_PAPER` 用來指定是否使用 Paper Trading 環境，設定為 `false` 即可連線到正式帳戶。
 
 建議透過 `python-dotenv` 在執行程式前載入 `.env`：
 

--- a/config.py
+++ b/config.py
@@ -7,4 +7,5 @@ load_dotenv()
 
 ALPACA_API_KEY = os.getenv("APCA_API_KEY_ID", "")
 ALPACA_SECRET_KEY = os.getenv("APCA_API_SECRET_KEY", "")
-USE_PAPER = True
+# 是否使用 Paper Trading 環境，可透過環境變數 ALPACA_USE_PAPER 設定
+USE_PAPER = os.getenv("ALPACA_USE_PAPER", "true").lower() == "true"


### PR DESCRIPTION
## Summary
- support `ALPACA_USE_PAPER` env flag in config
- document how to set `ALPACA_USE_PAPER` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2a49f9688329bd4c69b7f24a1210