### PR TITLE
Add route for dashboard CSS

### DIFF
--- a/api.py
+++ b/api.py
@@ -19,6 +19,13 @@ def dashboard():
     path = Path(__file__).parent / "dashboard" / "index.html"
     return FileResponse(path)
 
+
+@app.get("/styles.css")
+def dashboard_css():
+    """提供前端儀表板的樣式表"""
+    path = Path(__file__).parent / "dashboard" / "styles.css"
+    return FileResponse(path, media_type="text/css")
+
 _client = None
 
 


### PR DESCRIPTION
## Summary
- expose `/styles.css` so dashboard CSS is served correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c426296508329a1db36e558cbb66b