### PR TITLE
Update bot structure and dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -33,9 +33,14 @@
 
 <section class="section">
     <h2>Bots</h2>
-    <ul id="bots"></ul>
+    <table id="bots"></table>
     <div style="margin-top:12px;">
-        <input id="new-bot-name" placeholder="Bot name" />
+        <input id="new-bot-name" placeholder="Name" />
+        <input id="new-bot-strategy" placeholder="Strategy" />
+        <label style="margin-left:8px;">
+            <input type="checkbox" id="new-bot-enabled"> Enabled
+        </label>
+        <input id="new-bot-params" placeholder="Params JSON" />
         <button onclick="addBot()">Add</button>
     </div>
 </section>
@@ -83,26 +88,42 @@ async function fetchData() {
 async function loadBots() {
     try {
         const bots = await fetch("/bots").then(r => r.json());
-        const list = document.getElementById("bots");
-        list.innerHTML = "";
+        const table = document.getElementById("bots");
+        table.innerHTML = "";
+        table.insertAdjacentHTML("beforeend",
+            `<thead><tr><th>Name</th><th>Strategy</th><th>Enabled</th><th>Params</th><th></th></tr></thead>`);
+        const tbody = document.createElement("tbody");
         bots.forEach((bot, i) => {
-            list.insertAdjacentHTML("beforeend",
-                `<li>
-                    <input value="${bot.name || ""}" onchange="updateBot(${i}, this.value)">
-                    <button onclick="deleteBot(${i})">Delete</button>
-                 </li>`);
+            const row = `<tr>
+                <td><input value="${bot.name || ""}" onchange='updateBot(${i}, {name:this.value})'></td>
+                <td><input value="${bot.strategy || ""}" onchange='updateBot(${i}, {strategy:this.value})'></td>
+                <td style="text-align:center;"><input type="checkbox" ${bot.enabled ? "checked" : ""} onchange='updateBot(${i}, {enabled:this.checked})'></td>
+                <td><input value='${JSON.stringify(bot.params)}' onchange='updateBot(${i}, {params: JSON.parse(this.value || "{}")})'></td>
+                <td><button onclick='deleteBot(${i})'>Delete</button></td>
+            </tr>`;
+            tbody.insertAdjacentHTML("beforeend", row);
         });
+        table.appendChild(tbody);
     } catch (e) { console.error(e); }
 }
 async function addBot() {
     const name = document.getElementById("new-bot-name").value.trim();
-    if (!name) return;
-    await fetch("/bots", {method:"POST", headers:{'Content-Type':'application/json'}, body:JSON.stringify({name})});
+    const strategy = document.getElementById("new-bot-strategy").value.trim();
+    const enabled = document.getElementById("new-bot-enabled").checked;
+    let params = {};
+    try { params = JSON.parse(document.getElementById("new-bot-params").value || "{}"); } catch (e) { alert("Params JSON error"); return; }
+    await fetch("/bots", {
+        method:"POST",
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({name, strategy, enabled, params})});
     document.getElementById("new-bot-name").value = "";
+    document.getElementById("new-bot-strategy").value = "";
+    document.getElementById("new-bot-enabled").checked = false;
+    document.getElementById("new-bot-params").value = "";
     loadBots();
 }
-async function updateBot(id, name) {
-    await fetch(`/bots/${id}`, {method:"PUT", headers:{'Content-Type':'application/json'}, body:JSON.stringify({name})});
+async function updateBot(id, data) {
+    await fetch(`/bots/${id}`, {method:"PUT", headers:{'Content-Type':'application/json'}, body:JSON.stringify(data)});
 }
 async function deleteBot(id) {
     await fetch(`/bots/${id}`, {method:"DELETE"});

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -97,11 +97,6 @@ button:hover{
 }
 
 /* ===== Bot 清單 ===== */
-#bots{list-style:none;margin-top:4px}
-#bots li{
-    display:flex;
-    align-items:center;
-    gap:8px;
-    margin-bottom:10px;
+#bots td input{
+    width:100%;
 }
-#bots input{flex:1;width:auto}

--- a/robots.py
+++ b/robots.py
@@ -9,6 +9,14 @@ from typing import Any, Dict, List
 # 機器人資訊儲存檔案
 _ROBOTS_FILE = Path(__file__).with_name("robots.json")
 
+# 預設欄位
+_DEFAULT_BOT: Dict[str, Any] = {
+    "name": "",
+    "strategy": "",
+    "enabled": False,
+    "params": {},
+}
+
 # 內部快取
 _bots: List[Dict[str, Any]] | None = None
 
@@ -36,13 +44,18 @@ def _save() -> None:
 
 def get_bots() -> List[Dict[str, Any]]:
     """取得所有交易機器人資訊。"""
-    return list(_load())
+    bots = []
+    for bot in _load():
+        merged = {**_DEFAULT_BOT, **bot}
+        bots.append(merged)
+    return bots
 
 
 def add_bot(bot: Dict[str, Any]) -> None:
     """新增一個交易機器人並存檔。"""
     bots = _load()
-    bots.append(bot)
+    new_bot = {**_DEFAULT_BOT, **bot}
+    bots.append(new_bot)
     _save()
 
 
@@ -51,7 +64,9 @@ def update_bot(bot_id: int, bot: Dict[str, Any]) -> None:
     bots = _load()
     if bot_id < 0 or bot_id >= len(bots):
         raise IndexError("bot not found")
-    bots[bot_id] = bot
+    bots[bot_id].update(bot)
+    # 確保所有欄位皆存在
+    bots[bot_id] = {**_DEFAULT_BOT, **bots[bot_id]}
     _save()
 
 

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -10,13 +10,13 @@ import robots
 
 def test_get_bots_from_file(tmp_path, monkeypatch):
     data_file = tmp_path / "robots.json"
-    data_file.write_text('[{"name": "bot1"}]', encoding="utf-8")
+    data_file.write_text('[{"name": "bot1", "strategy": "s", "enabled": true, "params": {"a": 1}}]', encoding="utf-8")
 
     monkeypatch.setattr(robots, "_ROBOTS_FILE", data_file)
     robots._bots = None
 
     bots = robots.get_bots()
-    assert bots == [{"name": "bot1"}]
+    assert bots == [{"name": "bot1", "strategy": "s", "enabled": True, "params": {"a": 1}}]
 
 
 def test_api_get_bots(tmp_path):
@@ -27,7 +27,7 @@ def test_api_get_bots(tmp_path):
     api = importlib.import_module("api")
 
     data_file = tmp_path / "robots.json"
-    data_file.write_text('[{"name": "api_bot"}]', encoding="utf-8")
+    data_file.write_text('[{"name": "api_bot", "strategy": "st", "enabled": false, "params": {}}]', encoding="utf-8")
 
     import robots as robots_mod
     robots_mod._ROBOTS_FILE = data_file
@@ -36,7 +36,7 @@ def test_api_get_bots(tmp_path):
     client = TestClient(api.app)
     resp = client.get("/bots")
     assert resp.status_code == 200
-    assert resp.json() == [{"name": "api_bot"}]
+    assert resp.json() == [{"name": "api_bot", "strategy": "st", "enabled": False, "params": {}}]
 
 
 def test_bot_crud(tmp_path, monkeypatch):
@@ -44,15 +44,24 @@ def test_bot_crud(tmp_path, monkeypatch):
     monkeypatch.setattr(robots, "_ROBOTS_FILE", data_file)
     robots._bots = None
 
-    robots.add_bot({"name": "one"})
-    robots.add_bot({"name": "two"})
-    assert robots.get_bots() == [{"name": "one"}, {"name": "two"}]
+    robots.add_bot({"name": "one", "strategy": "s1", "enabled": True, "params": {}})
+    robots.add_bot({"name": "two", "strategy": "s2", "enabled": False, "params": {"x": 1}})
+    assert robots.get_bots() == [
+        {"name": "one", "strategy": "s1", "enabled": True, "params": {}},
+        {"name": "two", "strategy": "s2", "enabled": False, "params": {"x": 1}},
+    ]
 
-    robots.update_bot(1, {"name": "updated"})
-    assert robots.get_bots()[1] == {"name": "updated"}
+    robots.update_bot(1, {"name": "updated", "enabled": True})
+    updated = robots.get_bots()[1]
+    assert updated["name"] == "updated"
+    assert updated["enabled"] is True
+    assert updated["strategy"] == "s2"
+    assert updated["params"] == {"x": 1}
 
     robots.delete_bot(0)
-    assert robots.get_bots() == [{"name": "updated"}]
+    assert robots.get_bots() == [
+        {"name": "updated", "strategy": "s2", "enabled": True, "params": {"x": 1}}
+    ]
 
 
 def test_api_bot_crud(tmp_path):
@@ -69,13 +78,13 @@ def test_api_bot_crud(tmp_path):
 
     client = TestClient(api.app)
 
-    resp = client.post("/bots", json={"name": "bot"})
+    resp = client.post("/bots", json={"name": "bot", "strategy": "s", "enabled": False, "params": {}})
     assert resp.status_code == 200
-    assert robots_mod.get_bots() == [{"name": "bot"}]
+    assert robots_mod.get_bots() == [{"name": "bot", "strategy": "s", "enabled": False, "params": {}}]
 
-    resp = client.put("/bots/0", json={"name": "bot2"})
+    resp = client.put("/bots/0", json={"enabled": True})
     assert resp.status_code == 200
-    assert robots_mod.get_bots()[0] == {"name": "bot2"}
+    assert robots_mod.get_bots()[0]["enabled"] is True
 
     resp = client.delete("/bots/0")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- extend `robots` module to include `strategy`, `enabled` and `params`
- adjust CRUD helpers to merge new fields
- display bots as editable table on dashboard
- update bot style
- adapt unit tests for new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4613e5148329b84c16e76213694e