### PR TITLE
Implement filtered API responses

### DIFF
--- a/account.py
+++ b/account.py
@@ -28,9 +28,22 @@ def get_account_info(client: TradingClient) -> dict:
     }
 
 
-def get_positions(client: TradingClient):
-    """取得帳戶持倉資料列表。"""
-    return client.get_all_positions()
+def get_positions(client: TradingClient) -> List[dict]:
+    """取得帳戶持倉資料列表，並過濾只回傳必要欄位。"""
+    positions = client.get_all_positions()
+    result = []
+    for pos in positions:
+        result.append(
+            {
+                "symbol": pos.symbol,
+                "qty": str(getattr(pos, "qty", "")),
+                "avg_entry_price": str(getattr(pos, "avg_entry_price", "")),
+                "current_price": str(getattr(pos, "current_price", "")),
+                "unrealized_pl": str(getattr(pos, "unrealized_pl", "")),
+                "unrealized_plpc": str(getattr(pos, "unrealized_plpc", "")),
+            }
+        )
+    return result
 
 
 def get_trade_history(
@@ -38,7 +51,19 @@ def get_trade_history(
     *,
     status: QueryOrderStatus = QueryOrderStatus.CLOSED,
     limit: Optional[int] = None,
-) -> list:
-    """取得歷史訂單（交易）紀錄。"""
+) -> List[dict]:
+    """取得歷史訂單（交易）紀錄，僅保留必要欄位。"""
     req = GetOrdersRequest(status=status, limit=limit)
-    return client.get_orders(req)
+    orders = client.get_orders(req)
+    result = []
+    for od in orders:
+        result.append(
+            {
+                "symbol": od.symbol,
+                "qty": str(getattr(od, "qty", "")),
+                "side": getattr(od, "side", ""),
+                "filled_avg_price": str(getattr(od, "filled_avg_price", "")),
+                "status": getattr(od, "status", ""),
+            }
+        )
+    return result

--- a/api.py
+++ b/api.py
@@ -49,13 +49,13 @@ def get_account():
 @app.get("/positions")
 def positions():
     client = _ensure_client()
-    return account.get_positions(client)
+    return {"positions": account.get_positions(client)}
 
 
 @app.get("/orders")
 def orders(limit: Optional[int] = None):
     client = _ensure_client()
-    return account.get_trade_history(client, limit=limit)
+    return {"orders": account.get_trade_history(client, limit=limit)}
 
 
 @app.get("/bots")

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,84 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from pathlib import Path
+import pytest
+
+root_path = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_path))
+
+
+@pytest.fixture
+def account_module(monkeypatch):
+    alp_client = types.ModuleType('alpaca.trading.client')
+    alp_req = types.ModuleType('alpaca.trading.requests')
+    alp_enum = types.ModuleType('alpaca.trading.enums')
+    alp_client.TradingClient = object
+    alp_req.GetOrdersRequest = lambda **kw: kw
+    alp_enum.QueryOrderStatus = SimpleNamespace(CLOSED='closed')
+    monkeypatch.setitem(sys.modules, 'alpaca.trading.client', alp_client)
+    monkeypatch.setitem(sys.modules, 'alpaca.trading.requests', alp_req)
+    monkeypatch.setitem(sys.modules, 'alpaca.trading.enums', alp_enum)
+    sys.modules.pop('account', None)
+    mod = importlib.import_module('account')
+    yield mod
+    sys.modules.pop('account', None)
+
+
+def test_get_positions_filtered(account_module):
+    account = account_module
+
+    class DummyClient:
+        def get_all_positions(self):
+            return [
+                SimpleNamespace(
+                    symbol='AAPL',
+                    qty='10',
+                    avg_entry_price='100',
+                    current_price='110',
+                    unrealized_pl='10',
+                    unrealized_plpc='0.1',
+                    ignore='x',
+                )
+            ]
+
+    result = account.get_positions(DummyClient())
+    assert result == [
+        {
+            'symbol': 'AAPL',
+            'qty': '10',
+            'avg_entry_price': '100',
+            'current_price': '110',
+            'unrealized_pl': '10',
+            'unrealized_plpc': '0.1',
+        }
+    ]
+
+
+def test_get_trade_history_filtered(account_module):
+    account = account_module
+
+    class DummyClient:
+        def get_orders(self, req):
+            return [
+                SimpleNamespace(
+                    symbol='AAPL',
+                    qty='1',
+                    side='buy',
+                    filled_avg_price='105',
+                    status='filled',
+                    other='y',
+                )
+            ]
+
+    result = account.get_trade_history(DummyClient(), limit=1)
+    assert result == [
+        {
+            'symbol': 'AAPL',
+            'qty': '1',
+            'side': 'buy',
+            'filled_avg_price': '105',
+            'status': 'filled',
+        }
+    ]


### PR DESCRIPTION
## Summary
- filter account positions and trade history data
- return filtered results from positions/orders endpoints
- add tests for new account helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c467d56d48329b1c60640611d6f47