### PR TITLE
Add paginated trade history

### DIFF
--- a/account.py
+++ b/account.py
@@ -38,7 +38,16 @@ def get_trade_history(
     *,
     status: QueryOrderStatus = QueryOrderStatus.CLOSED,
     limit: Optional[int] = None,
+    page: int = 1,
 ) -> list:
-    """取得歷史訂單（交易）紀錄。"""
-    req = GetOrdersRequest(status=status, limit=limit)
-    return client.get_orders(req)
+    """取得歷史訂單（交易）紀錄，支援分頁。"""
+    req_limit = limit
+    if limit is not None and page > 1:
+        req_limit = limit * page
+    req = GetOrdersRequest(status=status, limit=req_limit)
+    orders = client.get_orders(req)
+    if limit is not None:
+        start = (page - 1) * limit
+        end = start + limit
+        return orders[start:end]
+    return orders

--- a/api.py
+++ b/api.py
@@ -53,9 +53,10 @@ def positions():
 
 
 @app.get("/orders")
-def orders(limit: Optional[int] = None):
+def orders(page: int = 1, limit: Optional[int] = None):
+    """取得歷史訂單並支援分頁查詢"""
     client = _ensure_client()
-    return account.get_trade_history(client, limit=limit)
+    return account.get_trade_history(client, limit=limit, page=page)
 
 
 @app.get("/bots")

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -27,7 +27,12 @@
 </section>
 
 <section class="section">
-    <h2>Orders (latest 5)</h2>
+    <h2>Orders</h2>
+    <div style="margin-bottom:8px;">
+        <button onclick="prevOrders()">Prev</button>
+        <span id="page-info" style="margin:0 8px;">1</span>
+        <button onclick="nextOrders()">Next</button>
+    </div>
     <table id="orders"></table>
 </section>
 
@@ -68,16 +73,25 @@ function renderArrayTable(arr, id) {
 }
 
 /* ---------- API 請求 ---------- */
+let orderPage = 1;
+const orderLimit = 5;
+
+async function fetchOrders(page = orderPage) {
+    const ord = await fetch(`/orders?page=${page}&limit=${orderLimit}`).then(r => r.json());
+    orderPage = page;
+    renderArrayTable(ord, "orders");
+    document.getElementById("page-info").textContent = page;
+}
+
 async function fetchData() {
     try {
-        const [acct, pos, ord] = await Promise.all([
+        const [acct, pos] = await Promise.all([
             fetch("/account").then(r => r.json()),
-            fetch("/positions").then(r => r.json()),
-            fetch("/orders?limit=5").then(r => r.json())
+            fetch("/positions").then(r => r.json())
         ]);
         renderObjectTable(acct, "account");
         renderArrayTable(pos, "positions");
-        renderArrayTable(ord, "orders");
+        fetchOrders(orderPage);
     } catch (e) { console.error(e); }
 }
 async function loadBots() {
@@ -107,6 +121,16 @@ async function updateBot(id, name) {
 async function deleteBot(id) {
     await fetch(`/bots/${id}`, {method:"DELETE"});
     loadBots();
+}
+
+function prevOrders() {
+    if (orderPage > 1) {
+        fetchOrders(orderPage - 1);
+    }
+}
+
+function nextOrders() {
+    fetchOrders(orderPage + 1);
 }
 
 /* ---------- INIT ---------- */

--- a/tests/test_orders_pagination.py
+++ b/tests/test_orders_pagination.py
@@ -1,0 +1,64 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+
+import pytest
+
+root_path = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root_path))
+
+
+def _setup_dummy_alpaca(monkeypatch):
+    alp_client = types.ModuleType('alpaca.trading.client')
+    alp_req = types.ModuleType('alpaca.trading.requests')
+    alp_enum = types.ModuleType('alpaca.trading.enums')
+
+    class DummyTradingClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_orders(self, req):
+            return [{'id': i} for i in range(1, 11)]
+
+    alp_client.TradingClient = DummyTradingClient
+    alp_req.GetOrdersRequest = lambda **kw: kw
+    alp_enum.QueryOrderStatus = types.SimpleNamespace(CLOSED='closed')
+
+    monkeypatch.setitem(sys.modules, 'alpaca.trading.client', alp_client)
+    monkeypatch.setitem(sys.modules, 'alpaca.trading.requests', alp_req)
+    monkeypatch.setitem(sys.modules, 'alpaca.trading.enums', alp_enum)
+
+    import account
+    importlib.reload(account)
+    return account
+
+
+def test_get_trade_history_page(monkeypatch):
+    acct = _setup_dummy_alpaca(monkeypatch)
+    client = acct.connect('k', 's')
+    orders = acct.get_trade_history(client, limit=3, page=2)
+    assert orders == [{'id': 4}, {'id': 5}, {'id': 6}]
+
+
+def test_api_orders_pagination(monkeypatch):
+    pytest.importorskip('fastapi')
+
+    acct = _setup_dummy_alpaca(monkeypatch)
+
+    import config
+    monkeypatch.setattr(config, 'ALPACA_API_KEY', 'key')
+    monkeypatch.setattr(config, 'ALPACA_SECRET_KEY', 'secret')
+    monkeypatch.setattr(config, 'USE_PAPER', True)
+
+    import api
+    importlib.reload(api)
+    api._client = None
+
+    from fastapi.testclient import TestClient
+    client = TestClient(api.app)
+
+    resp = client.get('/orders', params={'page': 2, 'limit': 3})
+    assert resp.status_code == 200
+    assert resp.json() == [{'id': 4}, {'id': 5}, {'id': 6}]
+


### PR DESCRIPTION
## Summary
- add pagination support in `account.get_trade_history`
- expose `page` on `/orders` API
- enhance dashboard with page navigation for orders
- test pagination on account module and API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c473d3150832987ffc6e1fed1f245