### PR TITLE
Add FastAPI and uvicorn to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 pip install -r requirements.txt
 ```
 
+`requirements.txt` 內已包含 `fastapi` 與啟動 API 所需的 `uvicorn`，安裝完成後即可使用 `uvicorn` 啟動 Web API。
+
 ## 設定環境變數
 
 請依照 `.env.example` 的格式新增一個 `.env` 檔案，內容範例如下：

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 alpaca-py==0.14
 python-dotenv
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- include FastAPI and uvicorn in dependencies
- document FastAPI install step in README

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c64ddb2ac8329b68928d87cbde2dd